### PR TITLE
Add host change environment action

### DIFF
--- a/app/controllers/concerns/foreman_puppet_enc/extensions/hosts_controller_extensions.rb
+++ b/app/controllers/concerns/foreman_puppet_enc/extensions/hosts_controller_extensions.rb
@@ -68,6 +68,7 @@ module ForemanPuppetEnc
         redirect_back_or_to hosts_path
       end
 
+      # TODO: seems to be useless
       def environment_from_param
         # simple validations
         if params[:environment].nil? || (id = params['environment']['id']).nil?

--- a/app/helpers/foreman_puppet_enc/hosts_helper.rb
+++ b/app/helpers/foreman_puppet_enc/hosts_helper.rb
@@ -6,7 +6,7 @@ module ForemanPuppetEnc
 
     def puppet_host_multiple_actions
       if ForemanPuppetEnc.extracted_from_core?
-        [{ action: [_('Change Environment'), select_multiple_environment_hosts_path], priority: 200 }]
+        [{ action: [_('Change Environment'), foreman_puppet_enc.select_multiple_environment_hosts_path], priority: 200 }]
       else
         []
       end

--- a/app/views/hosts/select_multiple_environment.html.erb
+++ b/app/views/hosts/select_multiple_environment.html.erb
@@ -1,0 +1,8 @@
+<%= render 'hosts/selected_hosts', hosts: @hosts %>
+
+<%= form_for :environment, url: foreman_puppet_enc.update_multiple_environment_hosts_path(host_ids: params[:host_ids]) do |f| %>
+    <%= selectable_f f, :id, [[_('Select environment'), 'disabled'],
+                        [_('*Clear environment*'), '' ],
+                        [_('*Inherit from host group*'), 'inherit']] + Environment.all.map{|e| [e.name, e.id]}, {},
+                     label: _('Environment'), onchange: 'tfm.hosts.table.toggleMultipleOkButton(this)' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,13 @@ ForemanPuppetEnc::Engine.routes.draw do
       end
     end
   end
+
+  resources :hosts, only: [], controller: '/hosts' do
+    collection do
+      match 'select_multiple_environment', via: %i[get post]
+      post 'update_multiple_environment'
+    end
+  end
 end
 
 Foreman::Application.routes.draw do

--- a/lib/foreman_puppet_enc.rb
+++ b/lib/foreman_puppet_enc.rb
@@ -2,7 +2,8 @@ module ForemanPuppetEnc
   FOREMAN_EXTRACTION_VERSION = '2.4'.freeze
 
   def self.extracted_from_core?
-    Gem::Dependency.new('', ">= #{FOREMAN_EXTRACTION_VERSION}").match?('', SETTINGS[:version])
+    ENV['PUPPET_EXTRACTED'] == '1' ||
+      Gem::Dependency.new('', ">= #{FOREMAN_EXTRACTION_VERSION}").match?('', SETTINGS[:version])
   end
 end
 

--- a/spec/views/hosts/select_multiple_environment.html.erb_spec.rb
+++ b/spec/views/hosts/select_multiple_environment.html.erb_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_puppet_enc_helper'
+
+describe 'hosts/select_multiple_environment.html.erb' do
+  let!(:environment) { FactoryBot.create(:environment, name: 'SpecialEnv') }
+
+  it 'renders the form' do
+    hosts = [FactoryBot.build_stubbed(:host)]
+    if ForemanPuppetEnc.extracted_from_core?
+      hosts.stubs(:preload).returns(hosts)
+    else
+      hosts.stubs(:includes).returns(hosts)
+    end
+    assign(:hosts, hosts)
+
+    render
+
+    expect(rendered).to have_selector('td', text: hosts.first.name)
+
+    expect(rendered).to have_selector('#environment_id option', text: '*Clear environment*')
+    expect(rendered).to have_selector('#environment_id option[value="inherit"]', text: '*Inherit from host group*')
+    expect(rendered).to have_selector("#environment_id option[value='#{environment.id}']", text: environment.name)
+  end
+end

--- a/test/controllers/foreman_puppet_enc/hosts_controller_test.rb
+++ b/test/controllers/foreman_puppet_enc/hosts_controller_test.rb
@@ -1,0 +1,47 @@
+require 'test_puppet_enc_helper'
+
+module ForemanPuppetEnc
+  class HostsControllerTest < ActionController::TestCase
+    tests ::HostsController
+
+    setup do
+      @routes = ForemanPuppetEnc::Engine.routes
+      as_admin do
+        host1
+        host2
+      end
+    end
+
+    let(:org) { users(:one).organizations.first }
+    let(:loc) { users(:one).locations.first }
+    let(:environment1) { FactoryBot.create(:environment, organizations: [org], locations: [loc]) }
+    let(:environment2) { FactoryBot.create(:environment, organizations: [org], locations: [loc]) }
+    let(:hostgroup) { FactoryBot.create(:hostgroup, environment: environment2, organizations: [org], locations: [loc]) }
+    let(:host_defaults) { { hostgroup: hostgroup, environment: environment1, organization: org, location: loc } }
+    let(:host1) { FactoryBot.create(:host, host_defaults) }
+    let(:host2) { FactoryBot.create(:host, host_defaults) }
+
+    test 'user with edit host rights with update environments should change environments' do
+      @request.env['HTTP_REFERER'] = '/hosts'
+      setup_user 'edit', 'hosts'
+
+      post :update_multiple_environment, params: { host_ids: [host1.id, host2.id],
+                                                   environment: { id: environment2.id } },
+                                         session: set_session_user(:one)
+      assert_equal environment2.id, host1.reload.environment_id
+      assert_equal environment2.id, host2.reload.environment_id
+      assert_equal 'Updated hosts: changed environment', flash[:success]
+    end
+
+    test 'should inherit the hostgroup environment if *inherit from hostgroup* selected' do
+      @request.env['HTTP_REFERER'] = '/hosts'
+      setup_user 'edit', 'hosts'
+
+      params = { host_ids: [host1.id, host2.id], environment: { id: 'inherit' } }
+      post :update_multiple_environment, params: params, session: set_session_user(:one)
+
+      assert_equal hostgroup.environment_id, host1.reload.environment_id
+      assert_equal hostgroup.environment_id, host2.reload.environment_id
+    end
+  end
+end

--- a/test/integration/foreman_puppet_enc/host_js_test.rb
+++ b/test/integration/foreman_puppet_enc/host_js_test.rb
@@ -1,0 +1,52 @@
+require 'test_puppet_enc_helper'
+require 'integration_test_helper'
+
+module ForemanPuppetEnc
+  class HostJSTest < IntegrationTestWithJavascript
+    setup do
+      @entries = Setting[:entries_per_page]
+      hosts
+    end
+
+    teardown do
+      Setting[:entries_per_page] = @entries
+    end
+
+    let(:environment) { FactoryBot.create(:environment) }
+    let(:hosts) { FactoryBot.create_list(:host, 3) }
+
+    describe 'multiple hosts selection' do
+      test 'apply bulk action, change environment on all hosts' do
+        environment
+        Setting[:entries_per_page] = 3
+        visit hosts_path(per_page: 2)
+        check 'check_all'
+        find('#multiple-alert > .text > a').click
+        find('#submit_multiple').click
+        find('a', text: /\AChange Environment\z/).click
+        find('#environment_id').find("option[value='#{environment.id}']").select_option
+        find('button', text: /\ASubmit\z/).click
+        assert page.has_text?(:all, 'Updated hosts: changed environment')
+      end
+    end
+
+    describe 'hosts index multiple actions' do
+      test 'redirect js' do
+        visit hosts_path
+        check 'check_all'
+
+        # Ensure and wait for all hosts to be checked, and that no unchecked hosts remain
+        assert page.has_no_selector?('input.host_select_boxes:not(:checked)')
+
+        # Hosts are added to cookie
+        host_ids_on_cookie = JSON.parse(CGI.unescape(get_me_the_cookie('_ForemanSelectedhosts')&.fetch(:value)))
+        assert_includes(host_ids_on_cookie, hosts.first.id)
+
+        page.execute_script("tfm.hosts.table.buildRedirect('#{foreman_puppet_enc.select_multiple_environment_hosts_path}')")
+        assert_current_path(foreman_puppet_enc.select_multiple_environment_hosts_path, ignore_query: true)
+
+        assert page.has_selector?('td', text: hosts.first.name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Missing pieces to `Change Environment` host multiple action.
We already have the menu item.
Adds the form itself and integration test.

Change host environment action needs to be added only if its extracted from core already.