### PR TITLE
Fix host(group) create forms

### DIFF
--- a/app/views/hosts/_form_puppet_enc_tab.html.erb
+++ b/app/views/hosts/_form_puppet_enc_tab.html.erb
@@ -1,6 +1,6 @@
 <% resource_type ||= pagelet.opts[:resource_type] %>
 <% host_or_hostgroup ||= local_assigns[resource_type] %>
-<% obj = host_or_hostgroup.puppet if %i[host hostgroup].include?(resource_type) %>
+<% obj = (host_or_hostgroup.puppet || host_or_hostgroup.build_puppet) if %i[host hostgroup].include?(resource_type) %>
 <% if resource_type == :host %>
 <span id="puppet_klasses_reload_url" data-url="<%= foreman_puppet_enc.hostgroup_or_environment_selected_hosts_path %>"></span>
 <% elsif resource_type == :hostgroup %>

--- a/webpack/src/foreman_puppet_host_form.js
+++ b/webpack/src/foreman_puppet_host_form.js
@@ -15,8 +15,9 @@ import * as LayoutActions from 'foremanReact/components/Layout/LayoutActions';
 export function loadPuppetClassParameters(item) {
   const id = $(item).data('class-id');
   // host_id could be either host.id OR hostgroup.id depending on which form
-  const hostId = $('form.hostresource-form').data('id');
-  if (!hostId) return; // it is not host nor hostgroup form - probably config_group
+  const $form = $('form.hostresource-form');
+  if ($form.length <= 0) return; // it is not host nor hostgroup form - probably config_group
+  const hostId = $form.data('id');
   if ($(`#puppetclass_${id}_params_loading`).length > 0) return; // already loading
   if ($(`[id^="#puppetclass_${id}_params\\["]`).length > 0) return; // already loaded
   const url = $(item).data('url');


### PR DESCRIPTION
Previously there was an check for Host(group) introduced.
But this check was based on an existing ID, that prevented new Host(group) form from loading parameters.
This is corretly preventing the configGroups from loading parameters, but loads them for new Host(group)