### PR TITLE
Add Environment to TemplateCombination

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,13 +8,13 @@ inherit_mode:
   merge:
     - Exclude
 
-AllCops:
-  Exclude:
-    - 'vendor/**/*'
-
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
   IndentationWidth: 2
+
+Naming/VariableNumber:
+  Exclude:
+    - 'test/**/*.rb'
 
 Rails/SkipsModelValidations:
   Exclude:

--- a/app/models/concerns/foreman_puppet_enc/extensions/provisioning_template.rb
+++ b/app/models/concerns/foreman_puppet_enc/extensions/provisioning_template.rb
@@ -1,0 +1,54 @@
+module ForemanPuppetEnc
+  module Extensions
+    module ProvisioningTemplate
+      extend ActiveSupport::Concern
+
+      included do
+        if ForemanPuppetEnc.extracted_from_core?
+          has_many :environments, through: :template_combinations
+
+          class << base
+            prepend PrependedClassMethods
+          end
+
+          prepend PrependedMethods
+        else
+          env_assoc = reflect_on_association(:environments)
+          env_assoc.instance_variable_set(:@class_name, 'ForemanPuppetEnc::Environment')
+        end
+      end
+
+      module PrependedClassMethods
+        def templates_by_template_combinations(templates, hosts_or_conditions)
+          if hosts_or_conditions.is_a?(Hash)
+            conditions = hosts_or_conditions
+            conditions[:hostgroup_id] = Array.wrap(conditions[:hostgroup_id]) | [nil]
+            conditions[:environment_id] = Array.wrap(conditions[:environment_id]) | [nil]
+          else
+            conditions = {}
+            conditions[:hostgroup_id] = hosts_or_conditions.pluck(:hostgroup_id) | [nil]
+            conditions[:environment_id] = hosts_or_conditions.pluck(:environment_id) | [nil]
+          end
+          at = TemplateCombination.arel_table
+          arel = at[:hostgroup_id].in(conditions[:hostgroup_id])
+          arel = arel.and(at[:environment_id].in(conditions[:environment_id]))
+          templates.joins(:template_combinations).where(arel).distinct
+        end
+
+        def template_includes
+          includes = super
+          tc_include = includes.detect { |i| i.key?(:template_combinations) }
+          tc_include ||= includes << {}
+          tc_include[:template_combinations] = %i[hostgroup environment]
+          includes
+        end
+      end
+
+      module PrependedMethods
+        def reject_template_combination_attributes?(params)
+          params[:environment_id].blank? && super(params)
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/foreman_puppet_enc/extensions/template_combination.rb
+++ b/app/models/concerns/foreman_puppet_enc/extensions/template_combination.rb
@@ -1,0 +1,18 @@
+module ForemanPuppetEnc
+  module Extensions
+    module TemplateCombination
+      extend ActiveSupport::Concern
+
+      included do
+        if ForemanPuppetEnc.extracted_from_core?
+          belongs_to :environment
+
+          validates :environment_id, uniqueness: { scope: %i[hostgroup_id provisioning_template_id] }
+        else
+          env_assoc = reflect_on_association(:environment)
+          env_assoc.instance_variable_set(:@class_name, 'ForemanPuppetEnc::Environment')
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20101121140000_add_environment_to_template_combinations.foreman_puppet_enc.rb
+++ b/db/migrate/20101121140000_add_environment_to_template_combinations.foreman_puppet_enc.rb
@@ -1,0 +1,9 @@
+class AddEnvironmentToTemplateCombinations < ActiveRecord::Migration[4.2]
+  def up
+    add_reference :template_combinations, :environment, foreign_key: true unless column_exists?(:template_combinations, :environment_id)
+  end
+
+  def down
+    remove_reference :template_combinations, :environment, foreign_key: true if column_exists?(:template_combinations, :environment_id)
+  end
+end

--- a/lib/foreman_puppet_enc/engine.rb
+++ b/lib/foreman_puppet_enc/engine.rb
@@ -35,6 +35,9 @@ module ForemanPuppetEnc
       Report.include ForemanPuppetEnc::Extensions::Report
       Taxonomy.include ForemanPuppetEnc::Extensions::Taxonomy
       User.include ForemanPuppetEnc::Extensions::User
+      TemplateCombination.include ForemanPuppetEnc::Extensions::TemplateCombination
+      ProvisioningTemplate.include ForemanPuppetEnc::Extensions::ProvisioningTemplate
+
       HostsController.include ForemanPuppetEnc::Extensions::HostsControllerExtensions
       HostgroupsController.include ForemanPuppetEnc::Extensions::HostgroupsControllerExtensions
 

--- a/test/factories/host_puppet_enhancements.rb
+++ b/test/factories/host_puppet_enhancements.rb
@@ -49,4 +49,8 @@ FactoryBot.modify do
       end
     end
   end
+
+  factory :template_combination do
+    environment
+  end
 end

--- a/test/models/foreman_puppet_enc/provisioning_template_test.rb
+++ b/test/models/foreman_puppet_enc/provisioning_template_test.rb
@@ -1,0 +1,124 @@
+require 'test_puppet_enc_helper'
+
+module ForemanPuppetEnc
+  class ProvisioningTemplateTest < ActiveSupport::TestCase
+    let(:environment) { FactoryBot.create(:environment) }
+
+    test 'should save assoications if not snippet' do
+      tmplt = ProvisioningTemplate.new
+      tmplt.name = 'Some finish script'
+      tmplt.template = 'echo $HOME'
+      tmplt.template_kind = template_kinds(:finish)
+      tmplt.snippet = false # this is the default, but it helps show the case
+      tmplt.hostgroups << hostgroups(:common)
+      tmplt.environments << environment
+      as_admin do
+        assert tmplt.save
+      end
+      assert_equal template_kinds(:finish), tmplt.template_kind
+      assert_equal [hostgroups(:common)], tmplt.hostgroups
+      assert_equal [environment], tmplt.environments
+    end
+
+    test 'should not save assoications if snippet' do
+      tmplt          = ProvisioningTemplate.new
+      tmplt.name     = 'Default Kickstart'
+      tmplt.template = 'Some kickstart goes here'
+      tmplt.snippet  = true
+      tmplt.template_kind = template_kinds(:ipxe)
+      tmplt.hostgroups << hostgroups(:common)
+      tmplt.environments << environment
+      as_admin do
+        assert tmplt.save
+      end
+      assert_nil tmplt.template_kind
+      assert_equal [], tmplt.hostgroups
+      assert_equal [], tmplt.environments
+      assert_equal [], tmplt.template_combinations
+    end
+
+    describe 'Association cascading' do
+      setup do
+        @arch = FactoryBot.create(:architecture)
+        medium = FactoryBot.create(:medium, name: 'combo_medium', path: 'http://www.example.com/m')
+        @os1 = FactoryBot.create(:rhel7_5, media: [medium], architectures: [@arch])
+        @hg1 = FactoryBot.create(:hostgroup, name: 'hg1', operatingsystem: @os1, architecture: @arch, medium: @os1.media.first)
+        @hg2 = FactoryBot.create(:hostgroup, name: 'hg2', operatingsystem: @os1, architecture: @arch)
+        @hg3 = FactoryBot.create(:hostgroup, name: 'hg3', operatingsystem: @os1, architecture: @arch)
+        @ev1 = FactoryBot.create(:environment, name: 'env1')
+        @ev2 = FactoryBot.create(:environment, name: 'env2')
+        @ev3 = FactoryBot.create(:environment, name: 'env3')
+
+        @tk = TemplateKind.find_by(name: 'provision')
+
+        # Most specific template association
+        @ct1 = FactoryBot.create(:provisioning_template, name: 'ct1', template_kind: @tk, operatingsystems: [@os1])
+        @ct1.template_combinations.create(hostgroup: @hg1, environment: @ev1)
+
+        # HG only
+        # We add an association on HG2/EV2 to ensure that we're not just blindly
+        # selecting all template_combinations where environment_id => nil
+        @ct2 = FactoryBot.create(:provisioning_template, name: 'ct2', template_kind: @tk, operatingsystems: [@os1])
+        @ct2.template_combinations.create(hostgroup: @hg1, environment: nil)
+        @ct2.template_combinations.create(hostgroup: @hg2, environment: @ev2)
+
+        # Env only
+        # We add an association on HG2/EV2 to ensure that we're not just blindly
+        # selecting all template_combinations where hostgroup_id => nil
+        @ct3 = FactoryBot.create(:provisioning_template, name: 'ct3', template_kind: @tk, operatingsystems: [@os1])
+        @ct3.template_combinations.create(hostgroup: nil, environment: @ev1)
+        @ct3.template_combinations.create(hostgroup: @hg2, environment: @ev2)
+
+        # Default template for the OS
+        @ctd = FactoryBot.create(:provisioning_template, name: 'ctd', template_kind: @tk, operatingsystems: [@os1])
+        @ctd.os_default_templates.create(operatingsystem: @os1, template_kind_id: @ctd.template_kind_id)
+      end
+
+      test 'find_template finds a matching template with hg and env' do
+        assert_equal @ct1.name,
+          ProvisioningTemplate.find_template({ kind: @tk.name,
+                                               operatingsystem_id: @os1.id,
+                                               hostgroup_id: @hg1.id,
+                                               environment_id: @ev1.id }).name
+      end
+
+      test 'find_template finds a matching template with hg only' do
+        assert_equal @ct2.name,
+          ProvisioningTemplate.find_template({ kind: @tk.name,
+                                               operatingsystem_id: @os1.id,
+                                               hostgroup_id: @hg1.id }).name
+      end
+
+      test 'find_template finds a matching template with hg and mismatched env' do
+        assert_equal @ct2.name,
+          ProvisioningTemplate.find_template({ kind: @tk.name,
+                                               operatingsystem_id: @os1.id,
+                                               hostgroup_id: @hg1.id,
+                                               environment_id: @ev3.id }).name
+      end
+
+      test 'find_template finds a matching template with env only' do
+        assert_equal @ct3.name,
+          ProvisioningTemplate.find_template({ kind: @tk.name,
+                                               operatingsystem_id: @os1.id,
+                                               environment_id: @ev1.id }).name
+      end
+
+      test 'find_template finds a matching template with env and mismatched hg' do
+        assert_equal @ct3.name,
+          ProvisioningTemplate.find_template({ kind: @tk.name,
+                                               operatingsystem_id: @os1.id,
+                                               hostgroup_id: @hg3.id,
+                                               environment_id: @ev1.id }).name
+      end
+
+      test 'find_template finds the default template when hg and env do not match' do
+        assert_equal @ctd.name,
+          ProvisioningTemplate.find_template({ kind: @tk.name,
+                                               operatingsystem_id: @os1.id,
+                                               hostgroup_id: @hg3.id,
+                                               environment_id: @ev3.id }).name
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add Environment to template combinations, to create the matrix, that was initially intended.
This might get removed in future.

Refs #97