### PR TITLE
Add Puppetclass to Host API

### DIFF
--- a/app/controllers/concerns/foreman_puppet_enc/extensions/api_v2_hosts_controller.rb
+++ b/app/controllers/concerns/foreman_puppet_enc/extensions/api_v2_hosts_controller.rb
@@ -17,23 +17,20 @@ module ForemanPuppetEnc
           apipie_update_methods(%i[create update]) do
             param :host, Hash do
               param :environment_id, String, desc: N_('Deprecated in favor of host/puppet_attributes/environment_id')
+              param :puppetclass_ids, Array, desc: N_('Deprecated in favor of host/puppet_attributes/puppetclass_ids')
+              param :config_group_ids, Array, desc: N_('Deprecated in favor of host/puppet_attributes/config_group_ids')
+
+              param :puppet_attributes, Hash do
+                param :environment_id, String, desc: N_('ID of associated puppet Environment')
+                param :puppetclass_ids, Array, desc: N_('IDs of associated Puppetclasses')
+                param :config_group_ids, Array, desc: N_('IDs of associated ConfigGroups')
+              end
             end
           end
         end
       end
 
       module PatchMethods
-        def host_attributes(params, host = nil)
-          environment_id = params.delete(:environment_id)
-          attrs = super(params, host)
-          if environment_id
-            ::Foreman::Deprecation.api_deprecation_warning('host[environment_id] has been deprecated in favor of host[puppet_attributes][environment_id]')
-            attrs[:puppet_attributes] ||= {}
-            attrs[:puppet_attributes][:environment_id] ||= environment_id
-          end
-          attrs
-        end
-
         def resource_name(*attrs)
           return 'foreman_puppet_enc/environment' if attrs.first.is_a?(String) &&
                                                      attrs.first.start_with?('environment')

--- a/app/controllers/concerns/foreman_puppet_enc/extensions/hosts_controller_extensions.rb
+++ b/app/controllers/concerns/foreman_puppet_enc/extensions/hosts_controller_extensions.rb
@@ -36,13 +36,6 @@ module ForemanPuppetEnc
         foreman_puppet_enc.select_multiple_puppet_proxy_hosts_path(*args)
       end
 
-      # params facets fix:
-      def host_params(top_level_hash = controller_name.singularize)
-        filter = self.class.host_params_filter
-        filter.permit(puppet_attributes: {})
-        filter.filter_params(params, parameter_filter_context, top_level_hash)
-      end
-
       def hostgroup_or_environment_selected
         refresh_host
         set_class_variables(@host)

--- a/app/controllers/concerns/foreman_puppet_enc/extensions/parameters_host.rb
+++ b/app/controllers/concerns/foreman_puppet_enc/extensions/parameters_host.rb
@@ -1,0 +1,68 @@
+module ForemanPuppetEnc
+  module Extensions
+    module ParametersHost
+      extend ActiveSupport::Concern
+
+      included do
+        class << self
+          prepend PatchedClassMethods
+        end
+
+        prepend PatchedMethods
+      end
+
+      module PatchedClassMethods
+        def host_params_filter
+          super.tap do |filter|
+            filter.permit :environment_id, :environment_name, :environment,
+              config_groups: [], config_group_ids: [], config_group_names: [],
+              puppetclasses: [], puppetclass_ids: [], puppetclass_names: []
+
+            # TODO: bring to core - this is what facets should do, but does not
+            filter.permit(puppet_attributes: {})
+          end
+        end
+      end
+
+      module PatchedMethods
+        def host_params(*attrs)
+          params = super(*attrs)
+
+          process_deprecated_environment_params!(params)
+          process_deprecated_attributes!(params)
+          params
+        end
+
+        def process_deprecated_environment_params!(params)
+          env_id = params.delete(:environment_id)
+          env_name = params.delete(:environment_name)
+          env = params.delete(:environment)
+
+          return if env_id || env_name || env
+          ::Foreman::Deprecation.api_deprecation_warning('param host[environment_*] has been deprecated in favor of host[puppet_attributes][environment_*]')
+
+          params[:puppet_attributes] ||= {}
+          params[:puppet_attributes][:environment_id] ||= env_id if env_id
+          params[:puppet_attributes][:environment_name] ||= env_name if env_name
+          params[:puppet_attributes][:environment] ||= env if env
+        end
+
+        def process_deprecated_attributes!(params)
+          %w[puppetclass config_groups].each do |relation|
+            ids = params.delete("#{relation}_ids".to_sym)
+            names = params.delete("#{relation}_names".to_sym)
+            plains = params.delete(relation.pluralize.to_sym)
+
+            next unless ids || names || plains
+            ::Foreman::Deprecation.api_deprecation_warning("param host[#{relation}_*] has been deprecated in favor of host[puppet_attributes][#{relation}_*]")
+
+            params[:puppet_attributes] ||= {}
+            params[:puppet_attributes]["#{relation}_ids".to_sym] ||= ids if ids
+            params[:puppet_attributes]["#{relation}_names".to_sym] ||= names if names
+            params[:puppet_attributes][relation.pluralize.to_sym] ||= plains if plains
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/foreman_puppet_enc/puppetclasses_controller.rb
+++ b/app/controllers/foreman_puppet_enc/puppetclasses_controller.rb
@@ -92,7 +92,7 @@ module ForemanPuppetEnc
           @obj.type = 'Host::Managed'
         end
         # puppetclass_ids and config_group_ids need to be removed so they don't cause automatic insertsgroup
-        @obj.attributes = host_params('host').except(:puppetclass_ids, :config_group_ids)
+        @obj.attributes = host_params('host')
       elsif params['hostgroup']
         # hostgroup.id is assigned to params['host_id'] by host_edit.js#load_puppet_class_parameters
         @obj = Hostgroup.find(host_id)

--- a/app/views/foreman_puppet_enc/api/v2/host_puppet_facets/base.json.rabl
+++ b/app/views/foreman_puppet_enc/api/v2/host_puppet_facets/base.json.rabl
@@ -1,0 +1,1 @@
+attributes :environment_id, :environment_name

--- a/app/views/foreman_puppet_enc/api/v2/host_puppet_facets/host_single.json.rabl
+++ b/app/views/foreman_puppet_enc/api/v2/host_puppet_facets/host_single.json.rabl
@@ -1,0 +1,17 @@
+child puppet: :puppet do
+  extends 'foreman_puppet_enc/api/v2/host_puppet_facets/show'
+end
+
+# backwards compatibility
+
+child root_object.puppet.puppetclasses => :puppetclasses do
+  extends 'foreman_puppet_enc/api/v2/puppetclasses/base'
+end
+
+node do |host|
+  { all_puppetclasses: partial('foreman_puppet_enc/api/v2/puppetclasses/base', object: host.puppet.all_puppetclasses) }
+end
+
+child root_object.puppet.config_groups => :config_groups do
+  extends 'foreman_puppet_enc/api/v2/config_groups/main'
+end

--- a/app/views/foreman_puppet_enc/api/v2/host_puppet_facets/main.json.rabl
+++ b/app/views/foreman_puppet_enc/api/v2/host_puppet_facets/main.json.rabl
@@ -1,5 +1,0 @@
-attributes :environment_id, :environment_name
-
-child root_object.puppet.config_groups => :config_groups do
-  extends 'foreman_puppet_enc/api/v2/config_groups/main'
-end

--- a/app/views/foreman_puppet_enc/api/v2/host_puppet_facets/show.json.rabl
+++ b/app/views/foreman_puppet_enc/api/v2/host_puppet_facets/show.json.rabl
@@ -1,0 +1,11 @@
+child :puppetclasses do
+  extends 'foreman_puppet_enc/api/v2/puppetclasses/base'
+end
+
+node do |puppet_facet|
+  { all_puppetclasses: partial('foreman_puppet_enc/api/v2/puppetclasses/base', object: puppet_facet.all_puppetclasses) }
+end
+
+child :config_groups do
+  extends 'foreman_puppet_enc/api/v2/config_groups/main'
+end

--- a/lib/foreman_puppet_enc/engine.rb
+++ b/lib/foreman_puppet_enc/engine.rb
@@ -21,6 +21,10 @@ module ForemanPuppetEnc
 
     # Include concerns in this config.to_prepare block
     config.to_prepare do
+      # Parameters should go ASAP as they need to be applied before they are included in core controller
+      Foreman::Controller::Parameters::Host.include ForemanPuppetEnc::Extensions::ParametersHost
+      Foreman::Controller::Parameters::TemplateCombination.include ForemanPuppetEnc::Extensions::ParametersTemplateCombination
+
       # Facets extenstion is applied too early - before the Hostgroup is complete
       # We redefine thing, so we need to wait until complete definition of Hostgroup
       # thus separate patching instead of using facet patching
@@ -37,8 +41,6 @@ module ForemanPuppetEnc
       User.include ForemanPuppetEnc::Extensions::User
       TemplateCombination.include ForemanPuppetEnc::Extensions::TemplateCombination
       ProvisioningTemplate.include ForemanPuppetEnc::Extensions::ProvisioningTemplate
-
-      Foreman::Controller::Parameters::TemplateCombination.include ForemanPuppetEnc::Extensions::ParametersTemplateCombination
 
       ::Api::V2::HostsController.include ForemanPuppetEnc::Extensions::ApiV2HostsController
       ::Api::V2::HostgroupsController.include ForemanPuppetEnc::Extensions::ApiHostgroupsController

--- a/lib/foreman_puppet_enc/register.rb
+++ b/lib/foreman_puppet_enc/register.rb
@@ -167,7 +167,8 @@ Foreman::Plugin.register :foreman_puppet_enc do
   register_facet ForemanPuppetEnc::HostPuppetFacet, :puppet do
     configure_host do
       # extend_model ForemanPuppetEnc::Extensions::Host
-      api_view single: 'foreman_puppet_enc/api/v2/host_puppet_facets/main'
+      api_view list: 'foreman_puppet_enc/api/v2/host_puppet_facets/base',
+               single: 'foreman_puppet_enc/api/v2/host_puppet_facets/host_single'
       template_compatibility_properties :environment, :environment_id, :environment_name
       set_dependent_action :destroy
     end

--- a/test/controllers/foreman_puppet_enc/api/v2/hosts_controller_test.rb
+++ b/test/controllers/foreman_puppet_enc/api/v2/hosts_controller_test.rb
@@ -9,13 +9,40 @@ module ForemanPuppetEnc
         let(:host) { FactoryBot.create(:host, :with_puppet_enc) }
 
         describe '#show' do
-          test 'include config_groups' do
+          test 'includes config_groups under puppet node' do
+            get :show, params: { id: host.to_param }
+            assert_response :success
+            json_response = ActiveSupport::JSON.decode(response.body)
+            assert json_response['puppet']['config_groups'].is_a? Array
+            response_cg_ids = json_response['puppet']['config_groups'].map { |cg| cg['id'] }
+            assert_equal host.puppet.config_groups.pluck(:id), response_cg_ids
+          end
+
+          test 'includes puppetclasses under puppet node' do
+            get :show, params: { id: host.to_param }
+            assert_response :success
+            json_response = ActiveSupport::JSON.decode(response.body)
+            assert json_response['puppet']['puppetclasses'].is_a? Array
+            response_pg_ids = json_response['puppet']['puppetclasses'].map { |pg| pg['id'] }
+            assert_equal host.puppet.puppetclasses.pluck(:id), response_pg_ids
+          end
+
+          test 'includes config_groups for backward compatibility' do
             get :show, params: { id: host.to_param }
             assert_response :success
             json_response = ActiveSupport::JSON.decode(response.body)
             assert json_response['config_groups'].is_a? Array
             response_cg_ids = json_response['config_groups'].map { |cg| cg['id'] }
             assert_equal host.puppet.config_groups.pluck(:id), response_cg_ids
+          end
+
+          test 'includes puppetclasses for backward compatibility' do
+            get :show, params: { id: host.to_param }
+            assert_response :success
+            json_response = ActiveSupport::JSON.decode(response.body)
+            assert json_response['puppetclasses'].is_a? Array
+            response_pg_ids = json_response['puppetclasses'].map { |pg| pg['id'] }
+            assert_equal host.puppet.puppetclasses.pluck(:id), response_pg_ids
           end
         end
 


### PR DESCRIPTION
Adds all puppetclass related bits to host API.
Adds puppetclasses and all_puppetclasses to host api response.
Adds puppetclass_ids parameter to API.