### PR TITLE
Fixes #33645 - remove react-intl from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,25 +21,22 @@
     "url": "http://projects.theforeman.org/projects/foreman_puppet/issues"
   },
   "peerDependencies": {
-    "@theforeman/vendor": ">= 6.0.0"
+    "@theforeman/vendor": "^8.15.0"
   },
   "devDependencies": {
     "@babel/core": "^7.7.0",
     "@sheerun/mutationobserver-shim": "^0.3.3",
-    "@theforeman/builder": "^6.0.0",
-    "@theforeman/eslint-plugin-foreman": "^6.0.0",
-    "@theforeman/find-foreman": "^4.8.0",
-    "@theforeman/stories": "^7.0.0",
-    "@theforeman/test": "^8.0.0",
-    "@theforeman/vendor-dev": "^6.0.0",
+    "@theforeman/builder": "^8.15.0",
+    "@theforeman/eslint-plugin-foreman": "^8.15.0",
+    "@theforeman/find-foreman": "^8.15.0",
+    "@theforeman/stories": "^8.15.0",
+    "@theforeman/test": "^8.15.0",
+    "@theforeman/vendor-dev": "^8.15.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.7.2",
+    "jed": "^1.1.1",
     "prettier": "^1.19.1",
     "stylelint-config-standard": "^18.0.0",
     "stylelint": "^9.3.0"
-  },
-  "dependencies": {
-    "jed": "^1.1.1",
-    "react-intl": "^2.8.0"
   }
 }


### PR DESCRIPTION
`react-intl` is now part of foreman-vendor 8.15.0
