### PR TITLE
View specs using only plugin routes

### DIFF
--- a/spec/spec_puppet_helper.rb
+++ b/spec/spec_puppet_helper.rb
@@ -16,26 +16,24 @@ FactoryBot.definition_file_paths.unshift(File.join(foreman_path, 'test', 'factor
 require 'factory_bot_rails'
 FactoryBot.reload
 
+module TestAuthorizeHelper
+  def authorizer
+    @authorizer ||= ::Authorizer.new(User.current, collection: instance_variable_get("@#{controller_name.split('/').last}"))
+  end
+end
+
 module ViewExampleGroupExtensions
   extend ActiveSupport::Concern
 
   included do
-    helper(LayoutHelper, AuthorizeHelper, TaxonomyHelper, PaginationHelper, ReactjsHelper)
+    helper(LayoutHelper, AuthorizeHelper, TaxonomyHelper, PaginationHelper, ReactjsHelper, TestAuthorizeHelper)
+    helper ForemanPuppet::Engine.routes.url_helpers
 
     before do
       path = _controller_path
       controller.class.define_method(:controller_name) do
         path
       end
-    end
-  end
-
-  def _controller_path
-    case _path_parts[1]
-    when 'puppetclasses'
-      _path_parts[1..-2].join('/')
-    else
-      super
     end
   end
 
@@ -49,7 +47,7 @@ end
 module ::ActionView
   class TestCase
     class TestController
-      helper_method :resource_path
+      helper_method :resource_path, :authorizer
 
       def resource_path(type)
         return '' if type.nil?

--- a/spec/views/foreman_puppet_enc/config_groups/edit.html.erb_spec.rb
+++ b/spec/views/foreman_puppet_enc/config_groups/edit.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_puppet_helper'
 
 describe 'foreman_puppet/config_groups/edit.html.erb' do
-  helper PuppetclassesHelper
+  helper ForemanPuppet::PuppetclassesHelper
 
   it 'renders the form' do
     config_group = FactoryBot.build_stubbed(:config_group, name: 'Special')

--- a/spec/views/foreman_puppet_enc/environments/new.html.erb_spec.rb
+++ b/spec/views/foreman_puppet_enc/environments/new.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'spec_puppet_helper'
 
 describe 'foreman_puppet/environments/new.html.erb' do
   it 'renders the form' do
-    assign(:environment, Environment.new)
+    assign(:environment, ForemanPuppet::Environment.new)
 
     render
 


### PR DESCRIPTION
All routes have been removed from core, so the specs will now fail on the workarounds to reroute to core.
This removes the workaround and fixes the issue.