### PR TITLE
Always return an array

### DIFF
--- a/app/models/foreman_puppet/host_puppet_facet.rb
+++ b/app/models/foreman_puppet/host_puppet_facet.rb
@@ -48,7 +48,7 @@ module ForemanPuppet
 
     def parent_config_groups
       return [] unless host.hostgroup
-      host.hostgroup.puppet&.all_config_groups
+      host.hostgroup.puppet&.all_config_groups || []
     end
 
     def ensure_puppet_associations

--- a/test/models/foreman_puppet/host_puppet_facet_test.rb
+++ b/test/models/foreman_puppet/host_puppet_facet_test.rb
@@ -107,7 +107,13 @@ module ForemanPuppet
       test 'should return empty array if host has no hostgroup' do
         host = FactoryBot.create(:host, :with_puppet_enc)
         assert_not host.hostgroup
-        assert_empty host.puppet.parent_config_groups
+        assert_equal [], host.puppet.parent_config_groups
+      end
+
+      test 'should return empty array if hostgroup do not have puppet data' do
+        hostgroup = FactoryBot.create(:hostgroup)
+        host = FactoryBot.create(:host, :with_puppet_enc, hostgroup: hostgroup)
+        assert_equal [], host.puppet.parent_config_groups
       end
     end
 


### PR DESCRIPTION
Ensures the return value of parent_config_groups is always array.

Fixes #206

Thanks @pkranenburg for reporting and sending the patch :)