### PR TITLE
Allows adding puppet param filters to other controllers

### DIFF
--- a/app/controllers/concerns/foreman_puppet/extensions/parameters_host.rb
+++ b/app/controllers/concerns/foreman_puppet/extensions/parameters_host.rb
@@ -14,12 +14,7 @@ module ForemanPuppet
       module PatchedClassMethods
         def host_params_filter
           super.tap do |filter|
-            filter.permit :environment_id, :environment_name, :environment,
-              config_groups: [], config_group_ids: [], config_group_names: [],
-              puppetclasses: [], puppetclass_ids: [], puppetclass_names: []
-
-            # TODO: bring to core - this is what facets should do, but does not
-            filter.permit(puppet_attributes: {})
+            add_host_puppet_params_filter(filter)
           end
         end
       end
@@ -27,40 +22,54 @@ module ForemanPuppet
       module PatchedMethods
         def host_params(*attrs)
           params = super(*attrs)
-
-          process_deprecated_environment_params!(params)
-          process_deprecated_attributes!(params)
+          process_deprecated_puppet_params!(params)
           params
         end
+      end
 
-        def process_deprecated_environment_params!(params)
-          env_id = params.delete(:environment_id)
-          env_name = params.delete(:environment_name)
-          env = params.delete(:environment)
+      class_methods do
+        def add_host_puppet_params_filter(filter)
+          filter.permit :environment_id, :environment_name, :environment,
+            config_groups: [], config_group_ids: [], config_group_names: [],
+            puppetclasses: [], puppetclass_ids: [], puppetclass_names: []
 
-          return unless env_id || env_name || env
-          ::Foreman::Deprecation.api_deprecation_warning('param host[environment_*] has been deprecated in favor of host[puppet_attributes][environment_*]')
+          # TODO: bring to core - this is what facets should do, but does not
+          filter.permit(puppet_attributes: {})
+        end
+      end
+
+      def process_deprecated_puppet_params!(params, top_level_hash = controller_name.singularize)
+        process_deprecated_environment_params!(params, top_level_hash)
+        process_deprecated_attributes!(params, top_level_hash)
+      end
+
+      def process_deprecated_environment_params!(params, top_level_hash = 'host')
+        env_id = params.delete(:environment_id)
+        env_name = params.delete(:environment_name)
+        env = params.delete(:environment)
+
+        return unless env_id || env_name || env
+        ::Foreman::Deprecation.api_deprecation_warning("param #{top_level_hash}[environment_*] has been deprecated in favor of #{top_level_hash}[puppet_attributes][environment_*]")
+
+        params[:puppet_attributes] ||= {}
+        params[:puppet_attributes][:environment_id] ||= env_id if env_id
+        params[:puppet_attributes][:environment_name] ||= env_name if env_name
+        params[:puppet_attributes][:environment] ||= env if env
+      end
+
+      def process_deprecated_attributes!(params, top_level_hash = 'host')
+        %w[puppetclass config_group].each do |relation|
+          ids = params.delete("#{relation}_ids".to_sym)
+          names = params.delete("#{relation}_names".to_sym)
+          plains = params.delete(relation.pluralize.to_sym)
+
+          next unless ids || names || plains
+          ::Foreman::Deprecation.api_deprecation_warning("param #{top_level_hash}[#{relation}_*] has been deprecated in favor of #{top_level_hash}[puppet_attributes][#{relation}_*]")
 
           params[:puppet_attributes] ||= {}
-          params[:puppet_attributes][:environment_id] ||= env_id if env_id
-          params[:puppet_attributes][:environment_name] ||= env_name if env_name
-          params[:puppet_attributes][:environment] ||= env if env
-        end
-
-        def process_deprecated_attributes!(params)
-          %w[puppetclass config_group].each do |relation|
-            ids = params.delete("#{relation}_ids".to_sym)
-            names = params.delete("#{relation}_names".to_sym)
-            plains = params.delete(relation.pluralize.to_sym)
-
-            next unless ids || names || plains
-            ::Foreman::Deprecation.api_deprecation_warning("param host[#{relation}_*] has been deprecated in favor of host[puppet_attributes][#{relation}_*]")
-
-            params[:puppet_attributes] ||= {}
-            params[:puppet_attributes]["#{relation}_ids".to_sym] ||= ids if ids
-            params[:puppet_attributes]["#{relation}_names".to_sym] ||= names if names
-            params[:puppet_attributes][relation.pluralize.to_sym] ||= plains if plains
-          end
+          params[:puppet_attributes]["#{relation}_ids".to_sym] ||= ids if ids
+          params[:puppet_attributes]["#{relation}_names".to_sym] ||= names if names
+          params[:puppet_attributes][relation.pluralize.to_sym] ||= plains if plains
         end
       end
     end

--- a/app/controllers/concerns/foreman_puppet/extensions/parameters_hostgroup.rb
+++ b/app/controllers/concerns/foreman_puppet/extensions/parameters_hostgroup.rb
@@ -14,12 +14,7 @@ module ForemanPuppet
       module PatchedClassMethods
         def hostgroup_params_filter
           super.tap do |filter|
-            filter.permit :environment_id, :environment_name,
-              config_group_ids: [], config_group_names: [],
-              puppetclass_ids: [], puppetclass_names: []
-
-            # TODO: bring to core - this is what facets should do, but does not
-            filter.permit(puppet_attributes: {})
+            add_hostgroup_puppet_params_filter(filter)
           end
         end
       end
@@ -27,36 +22,50 @@ module ForemanPuppet
       module PatchedMethods
         def hostgroup_params(*attrs)
           params = super(*attrs)
-
-          process_deprecated_hostgroup_environment_params!(params)
-          process_deprecated_hostgroup_attributes!(params)
+          process_deprecated_hostgroup_puppet_params!(params)
           params
         end
+      end
 
-        def process_deprecated_hostgroup_environment_params!(params)
-          env_id = params.delete(:environment_id)
-          env_name = params.delete(:environment_name)
+      class_methods do
+        def add_hostgroup_puppet_params_filter(filter)
+          filter.permit :environment_id, :environment_name,
+            config_group_ids: [], config_group_names: [],
+            puppetclass_ids: [], puppetclass_names: []
 
-          return unless env_id || env_name
-          ::Foreman::Deprecation.api_deprecation_warning('param hostgroup[environment_*] has been deprecated in favor of hostgroup[puppet_attributes][environment_*]')
+          # TODO: bring to core - this is what facets should do, but does not
+          filter.permit(puppet_attributes: {})
+        end
+      end
+
+      def process_deprecated_hostgroup_puppet_params!(params, top_level_hash = 'hostgroup')
+        process_deprecated_hostgroup_environment_params!(params, top_level_hash)
+        process_deprecated_hostgroup_attributes!(params, top_level_hash)
+      end
+
+      def process_deprecated_hostgroup_environment_params!(params, top_level_hash = 'hostgroup')
+        env_id = params.delete(:environment_id)
+        env_name = params.delete(:environment_name)
+
+        return unless env_id || env_name
+        ::Foreman::Deprecation.api_deprecation_warning("param #{top_level_hash}[environment_*] has been deprecated in favor of #{top_level_hash}[puppet_attributes][environment_*]")
+
+        params[:puppet_attributes] ||= {}
+        params[:puppet_attributes][:environment_id] ||= env_id if env_id
+        params[:puppet_attributes][:environment_name] ||= env_name if env_name
+      end
+
+      def process_deprecated_hostgroup_attributes!(params, top_level_hash = 'hostgroup')
+        %w[puppetclass config_group].each do |relation|
+          ids = params.delete("#{relation}_ids")
+          names = params.delete("#{relation}_names")
+
+          next unless ids || names
+          ::Foreman::Deprecation.api_deprecation_warning("param #{top_level_hash}[#{relation}_*] has been deprecated in favor of #{top_level_hash}[puppet_attributes][#{relation}_*]")
 
           params[:puppet_attributes] ||= {}
-          params[:puppet_attributes][:environment_id] ||= env_id if env_id
-          params[:puppet_attributes][:environment_name] ||= env_name if env_name
-        end
-
-        def process_deprecated_hostgroup_attributes!(params)
-          %w[puppetclass config_group].each do |relation|
-            ids = params.delete("#{relation}_ids")
-            names = params.delete("#{relation}_names")
-
-            next unless ids || names
-            ::Foreman::Deprecation.api_deprecation_warning("param hostgroup[#{relation}_*] has been deprecated in favor of hostgroup[puppet_attributes][#{relation}_*]")
-
-            params[:puppet_attributes] ||= {}
-            params[:puppet_attributes]["#{relation}_ids".to_sym] ||= ids if ids
-            params[:puppet_attributes]["#{relation}_names".to_sym] ||= names if names
-          end
+          params[:puppet_attributes]["#{relation}_ids".to_sym] ||= ids if ids
+          params[:puppet_attributes]["#{relation}_names".to_sym] ||= names if names
         end
       end
     end


### PR DESCRIPTION
Puppet params Host/group filters were not written in other controllers in mind.
This adds add_host(group)_puppet_params_filter to ease up integration