### PR TITLE
Add Packit commit trigger job

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -25,7 +25,8 @@ actions:
     - bash -c "ls -1t ./foreman_puppet-*.gem | head -n 1"
 
 jobs:
-  - job: copr_build
+  - &copr
+    job: copr_build
     trigger: pull_request
     targets:
       rhel-9:
@@ -33,6 +34,12 @@ jobs:
         additional_repos:
           - https://yum.theforeman.org/releases/nightly/el9/x86_64/
           - https://yum.theforeman.org/plugins/nightly/el9/x86_64/
+
+  - <<: *copr
+    trigger: commit
+    branch: master
+    owner: '@theforeman'
+    project: develop
 
 srpm_build_deps:
   - wget


### PR DESCRIPTION
This PR adds a second Packit job that triggers on commits to the default branch.

The new job:
- Inherits configuration from the existing pull_request job using YAML anchors
- Triggers on commits to the default branch
- Builds in the @theforeman/develop COPR project
- Uses the same targets and configuration as PR builds

This enables automated COPR builds on commits, making it easier to test changes from the development branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)