### PR TITLE
Show the view state of puppet modules/classes using chevrons on puppetclass selection page

### DIFF
--- a/app/views/foreman_puppet/puppetclasses/_classes.html.erb
+++ b/app/views/foreman_puppet/puppetclasses/_classes.html.erb
@@ -2,21 +2,36 @@
   <div class="col-md-6 classes">
     <% group.each do |list| %>
       <% next if list.nil? %>
-      <ul class="puppetclass_group">
-        <li><%= puppetclass_group_with_icon(list, selected_puppet_classes) %>
-          <ul id="pc_<%= list.first %>" style="display: none;">
-            <% for klass in list.last.sort %>
-              <% unless authorized_for(controller: :host_editing, action: :edit_classes) %>
-                <li data-original-title="<%= _('Not authorized to edit classes') %>" rel="twipsy"><%= h klass.name %></li>
-              <% else %>
-                <li id="puppetclass_<%= klass.id %>" class="puppetclass<%= ' hide' if selected_puppet_classes.include?(klass) %>">
-                  <%= link_to_add_puppetclass(klass, resource_type) %>
-                </li>
-              <% end %>
-            <% end %>
-          </ul>
-        </li>
-      </ul>
+
+      <div class="panel-group paneless puppetclass_group" id="<%= list.first %>-avail-classes" style="margin-bottom: 1px;">
+	<div class="panel-heading" style="padding-top: 2px; padding-bottom: 2px;">
+	  <p class="panel-title">
+	    <a data-toggle="collapse" data-parent="#<%= list.first %>-avail-classes" href="#<%= list.first %>-avail-classes-list" class="collapsed">
+	      <%= h list.first %>
+	    </a>
+	  </p>
+	</div>
+	<div id="<%= list.first %>-avail-classes-list" class="panel-collapse collapse">
+	  <div class="panel-body">
+	    <ul style="margin-bottom: 1px;">
+	      <% for klass in list.last.sort %>
+	        <% unless authorized_for(:controller => :host_editing, :action => :edit_classes) %>
+	          <li data-original-title="<%= _('Not authorized to edit classes') %>" rel="twipsy">
+	            <%= h klass.name %>
+		  </li>
+		<% else %>
+		  <% style = ["puppetclass",
+		              selected_puppet_classes.include?(klass) ? "hide" : "",
+		             ].join(' ') %>
+		  <%= content_tag(:li, klass, :id=>"puppetclass_#{klass.id}", :class=>style) do %>
+                    <%= link_to_add_puppetclass(klass,type) %>
+		  <% end %>
+		<% end %>
+	      <% end %>
+	    </ul>
+	  </div>
+	</div>
+      </div>
     <% end %>
   </div>
 <% end %>

--- a/app/views/foreman_puppet/puppetclasses/_classes.html.erb
+++ b/app/views/foreman_puppet/puppetclasses/_classes.html.erb
@@ -4,33 +4,33 @@
       <% next if list.nil? %>
 
       <div class="panel-group paneless puppetclass_group" id="<%= list.first %>-avail-classes" style="margin-bottom: 1px;">
-	<div class="panel-heading" style="padding-top: 2px; padding-bottom: 2px;">
-	  <p class="panel-title">
-	    <a data-toggle="collapse" data-parent="#<%= list.first %>-avail-classes" href="#<%= list.first %>-avail-classes-list" class="collapsed">
-	      <%= h list.first %>
-	    </a>
-	  </p>
-	</div>
-	<div id="<%= list.first %>-avail-classes-list" class="panel-collapse collapse">
-	  <div class="panel-body">
-	    <ul style="margin-bottom: 1px;">
-	      <% for klass in list.last.sort %>
-	        <% unless authorized_for(:controller => :host_editing, :action => :edit_classes) %>
-	          <li data-original-title="<%= _('Not authorized to edit classes') %>" rel="twipsy">
-	            <%= h klass.name %>
-		  </li>
-		<% else %>
-		  <% style = ["puppetclass",
-		              selected_puppet_classes.include?(klass) ? "hide" : "",
-		             ].join(' ') %>
-		  <%= content_tag(:li, klass, :id=>"puppetclass_#{klass.id}", :class=>style) do %>
-                    <%= link_to_add_puppetclass(klass,type) %>
-		  <% end %>
-		<% end %>
-	      <% end %>
-	    </ul>
-	  </div>
-	</div>
+        <div class="panel-heading" style="padding-top: 2px; padding-bottom: 2px;">
+          <p class="panel-title">
+            <a data-toggle="collapse" data-parent="#<%= list.first %>-avail-classes" href="#<%= list.first %>-avail-classes-list" class="collapsed">
+              <%= h list.first %>
+            </a>
+          </p>
+        </div>
+        <div id="<%= list.first %>-avail-classes-list" class="panel-collapse collapse">
+          <div class="panel-body">
+            <ul style="margin-bottom: 1px;">
+              <% for klass in list.last.sort %>
+                <% unless authorized_for(:controller => :host_editing, :action => :edit_classes) %>
+                  <li data-original-title="<%= _('Not authorized to edit classes') %>" rel="twipsy">
+                    <%= h klass.name %>
+                  </li>
+                <% else %>
+                  <% style = ["puppetclass",
+                              selected_puppet_classes.include?(klass) ? "hide" : "",
+                             ].join(' ') %>
+                  <%= content_tag(:li, klass, :id => "puppetclass_#{klass.id}", :class => style) do %>
+                    <%= link_to_add_puppetclass(klass, type) %>
+                  <% end %>
+                <% end %>
+              <% end %>
+            </ul>
+          </div>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/foreman_puppet/puppetclasses/_classes.html.erb
+++ b/app/views/foreman_puppet/puppetclasses/_classes.html.erb
@@ -3,8 +3,8 @@
     <% group.each do |list| %>
       <% next if list.nil? %>
 
-      <div class="panel-group paneless puppetclass_group" id="<%= list.first %>-avail-classes" style="margin-bottom: 1px;">
-        <div class="panel-heading" style="padding-top: 2px; padding-bottom: 2px;">
+      <div class="panel-group paneless puppetclass_group" id="<%= list.first %>-avail-classes">
+        <div class="panel-heading">
           <p class="panel-title">
             <a data-toggle="collapse" data-parent="#<%= list.first %>-avail-classes" href="#<%= list.first %>-avail-classes-list" class="collapsed">
               <%= h list.first %>
@@ -13,7 +13,7 @@
         </div>
         <div id="<%= list.first %>-avail-classes-list" class="panel-collapse collapse">
           <div class="panel-body">
-            <ul style="margin-bottom: 1px;">
+            <ul>
               <% for klass in list.last.sort %>
                 <% unless authorized_for(:controller => :host_editing, :action => :edit_classes) %>
                   <li data-original-title="<%= _('Not authorized to edit classes') %>" rel="twipsy">

--- a/webpack/src/foreman_class_edit.js
+++ b/webpack/src/foreman_class_edit.js
@@ -28,9 +28,18 @@ export function filterPuppetClasses(item) {
     classElems
       .hide()
       .has(`[data-class-name*="${term}"]`)
-      .show();
+      .show()
+      .filter('div')
+      .find('a.collapsed')
+      .attr('aria-expanded','true')
+      .click();
   } else {
-    classElems.show();
+    classElems
+      .show()
+      .has('.collapse')
+      .find('a[aria-expanded]')
+      .attr('aria-expanded','false')
+      .click();
   }
 }
 


### PR DESCRIPTION
This commit changes the add puppet class view to be a bit more like a tree by changing the big + to be a right chevron or down chevron if the module has been opened.

When I have shown people how to create machines with the help of foreman, many have wondered what the difference between the '+' symbols when adding puppet classes are. 

Original (from foreman 3.19.0 + foreman_puppet 10.1.1):
<img width="858" height="286" alt="Screenshot From 2026-06-20 15-35-25" src="https://github.com/user-attachments/assets/d9bb012a-3de1-46e0-8297-51e51288307f" />

Changed version:
<img width="858" height="286" alt="Screenshot From 2026-06-20 21-57-30" src="https://github.com/user-attachments/assets/3f17952f-9eb8-485d-880d-f1b09f11c8d4" />
