### PR TITLE
Switch manual links to point to docs

### DIFF
--- a/app/views/foreman_puppet/config_groups/welcome.html.erb
+++ b/app/views/foreman_puppet/config_groups/welcome.html.erb
@@ -8,6 +8,6 @@
                                     :iconType => 'fa',
                                     :header => _('Config Groups'),
                                     :description => description,
-                                    :documentation => { :url => documentation_url("using-config-groups") },
+                                    :documentation => { :url => documentation_url("Managing_Configurations_Puppet", type: 'docs', chapter: 'creating-a-puppet-config-group_managing-configurations-puppet') },
                                     :action => action
                                   }) %>

--- a/app/views/foreman_puppet/puppetclass_lookup_keys/index.html.erb
+++ b/app/views/foreman_puppet/puppetclass_lookup_keys/index.html.erb
@@ -1,5 +1,5 @@
 <% title _("Smart Class Parameters") %>
-<% title_actions documentation_button('4.2.5ParameterizedClasses') %>
+<% title_actions documentation_button('Managing_Configurations_Puppet', type: 'docs', chapter: 'Configuring_Puppet_Smart_Class_Parameters_managing-configurations-puppet') %>
 <table class="<%= table_css_classes 'table-fixed' %>">
   <thead>
     <tr>

--- a/app/views/foreman_puppet/puppetclass_lookup_keys/welcome.html.erb
+++ b/app/views/foreman_puppet/puppetclass_lookup_keys/welcome.html.erb
@@ -7,5 +7,5 @@
                                     :iconType => 'fa',
                                     :header => _('Smart Class Parameters'),
                                     :description => description,
-                                    :documentation => { :url => documentation_url("4.2.5SmartMatchers") },
+                                    :documentation => { :url => documentation_url('Managing_Configurations_Puppet', type: 'docs', chapter: 'Configuring_Puppet_Smart_Class_Parameters_managing-configurations-puppet') },
                                   }) %>

--- a/app/views/foreman_puppet/puppetclasses/_form.html.erb
+++ b/app/views/foreman_puppet/puppetclasses/_form.html.erb
@@ -35,7 +35,7 @@
             </div>
           </div>
           <div class='col-md-6 text-right'>
-            <%= documentation_button('4.2.5ParameterizedClasses') %>
+            <%= documentation_button('Managing_Configurations_Puppet', type: 'docs', chapter: 'Configuring_Puppet_Smart_Class_Parameters_managing-configurations-puppet') %>
           </div>
         </div>
         <div class="smart-var-left col-md-3">

--- a/app/views/foreman_puppet/puppetclasses/index.html.erb
+++ b/app/views/foreman_puppet/puppetclasses/index.html.erb
@@ -1,7 +1,7 @@
 <% title _("Puppet Classes") %>
 
 <% title_actions import_proxy_select(hash_for_import_environments_puppetclasses_path.merge(engine: foreman_puppet)),
-                 documentation_button('4.2.2Classes') %>
+                 documentation_button('Managing_Configurations_Puppet', type: 'docs', chapter: 'Importing_Puppet_Classes_and_Environments_managing-configurations-puppet') %>
 
 <table class="<%= table_css_classes 'table-fixed' %>">
   <thead>

--- a/webpack/src/Components/Environments/Welcome.js
+++ b/webpack/src/Components/Environments/Welcome.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { translate as __ } from 'foremanReact/common/I18n';
 import EmptyState from 'foremanReact/components/common/EmptyState';
-import { foremanUrl, getManualURL } from 'foremanReact/common/helpers';
+import { foremanUrl, getDocsURL } from 'foremanReact/common/helpers';
 
 export const WelcomeEnv = ({ canCreate }) => {
   const action = canCreate && {
@@ -23,7 +23,10 @@ export const WelcomeEnv = ({ canCreate }) => {
           puppetClassesLinkToDocs: (
             <a
               target="_blank"
-              href={getManualURL('4.2.2Classes')}
+              href={getDocsURL(
+                'Managing_Configurations_Puppet',
+                'Importing_Puppet_Classes_and_Environments_managing-configurations-puppet'
+              )}
               rel="noreferrer"
             >
               {__('Puppet classes')}
@@ -39,7 +42,12 @@ export const WelcomeEnv = ({ canCreate }) => {
       iconType="fa"
       header={__('Puppet Environments')}
       description={description}
-      documentation={{ url: getManualURL('4.2.1Environments') }}
+      documentation={{
+        url: getDocsURL(
+          'Managing_Configurations_Puppet',
+          'Creating_a_Custom_Puppet_Environment_managing-configurations-puppet'
+        ),
+      }}
       action={action}
     />
   );


### PR DESCRIPTION
Draft until I figure out a replacement for `4.2.5ParameterizedClasses` which doesn't seem to have a direct counterpart in the new docs.