### PR TITLE
Remove deprecation warning for Puppet (CA) Proxy bulk action

### DIFF
--- a/app/controllers/foreman_puppet/api/v2/puppet_base_controller.rb
+++ b/app/controllers/foreman_puppet/api/v2/puppet_base_controller.rb
@@ -11,7 +11,7 @@ module ForemanPuppet
         protected
 
         def show_deprecation_for_core_routes
-          return if request.path.starts_with?('/foreman_puppet') || request.path.starts_with?('/api/smart_proxies')
+          return if request.path.starts_with?('/foreman_puppet') || request.path.starts_with?('/api/smart_proxies') || request.path.starts_with?('/api/v2/hosts/bulk/')
           Foreman::Deprecation.api_deprecation_warning(
             format(
               '/api/v2/%{controller} API endpoints are deprecated, please use /foreman_puppet/api/v2/%{controller} instead',


### PR DESCRIPTION
We have still endpoints in foreman core namespace although they have been implemented a long time ago in the foreman_puppet plugin. They were implemented to ease the transfer of extracting the Puppet feature to plugin. This is round about 5 years ago. 

I suggest that we remove those endpoints for Foreman 5.0, means soon. I know that this proposal makes this PR somehow seeming unnecessary, but I'd vote to have it as a quick fix and then thoroughly look at the rest of the routes.    