### PR TITLE
Fix JS linting error 'no-magic-numbers'

### DIFF
--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -12,6 +12,8 @@ import BulkChangePuppetCAProxy from './src/Extends/Hosts/BulkActions/BulkChangeP
 import BulkRemovePuppetProxy from './src/Extends/Hosts/BulkActions/BulkRemovePuppetProxy';
 import BulkRemovePuppetCAProxy from './src/Extends/Hosts/BulkActions/BulkRemovePuppetCAProxy';
 
+const GLOBAL_FILL_PRIORITY = 100;
+
 // register reducers
 registerReducer('puppet', reducers);
 // add fills
@@ -40,35 +42,35 @@ addGlobalFill(
   'hosts-index-kebab',
   'puppet-hosts-index-kebab',
   <HostsIndexActionsBar key="puppet-hosts-index-kebab" />,
-  100
+  GLOBAL_FILL_PRIORITY
 );
 
 addGlobalFill(
   '_all-hosts-modals',
   'BulkChangePuppetProxy',
   <BulkChangePuppetProxy key="bulk-change-puppet-proxy" />,
-  100
+  GLOBAL_FILL_PRIORITY
 );
 
 addGlobalFill(
   '_all-hosts-modals',
   'BulkChangePuppetCAProxy',
   <BulkChangePuppetCAProxy key="bulk-change-puppet-ca-proxy" />,
-  100
+  GLOBAL_FILL_PRIORITY
 );
 
 addGlobalFill(
   '_all-hosts-modals',
   'BulkRemovePuppetCAProxy',
   <BulkRemovePuppetCAProxy key="bulk-remove-puppet-ca-proxy" />,
-  100
+  GLOBAL_FILL_PRIORITY
 );
 
 addGlobalFill(
   '_all-hosts-modals',
   'BulkRemovePuppetProxy',
   <BulkRemovePuppetProxy key="bulk-remove-puppet-proxy" />,
-  100
+  GLOBAL_FILL_PRIORITY
 );
 
 registerColumns(puppetHostsIndexColumns);

--- a/webpack/src/foreman_class_edit.js
+++ b/webpack/src/foreman_class_edit.js
@@ -17,6 +17,8 @@
 import $ from 'jquery';
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 
+const HIGHLIGHT_DURATION = 5000;
+
 export function filterPuppetClasses(item) {
   const term = $(item)
     .val()
@@ -59,7 +61,7 @@ export function addPuppetClass(item) {
 
   $('#selected_classes').append(content);
 
-  $(`#selected_puppetclass_${id}`).show('highlight', 5000);
+  $(`#selected_puppetclass_${id}`).show('highlight', HIGHLIGHT_DURATION);
   $(`#puppetclass_${id}`)
     .addClass('selected-marker')
     .hide();
@@ -87,7 +89,7 @@ function addGroupPuppetClass(item) {
 
   $('#selected_classes').append(content);
 
-  $(`#selected_puppetclass_${id}`).show('highlight', 5000);
+  $(`#selected_puppetclass_${id}`).show('highlight', HIGHLIGHT_DURATION);
   $(`#puppetclass_${id}`)
     .addClass('selected-marker')
     .hide();
@@ -136,7 +138,7 @@ export function addConfigGroup(item) {
   content.append(
     `<input id='config_group_ids' name=${type}[config_group_ids][] type='hidden' value=${id}>`
   );
-  $(`#selected_config_group_${id}`).show('highlight', 5000);
+  $(`#selected_config_group_${id}`).show('highlight', HIGHLIGHT_DURATION);
   $(`#config_group_${id}`)
     .addClass('selected-marker')
     .hide();
@@ -149,7 +151,7 @@ export function addConfigGroup(item) {
   link.text(__(' Remove'));
 
   $('#selected_config_groups').append(content);
-  $(`#selected_config_group_${id}`).show('highlight', 5000);
+  $(`#selected_config_group_${id}`).show('highlight', HIGHLIGHT_DURATION);
   $(`#config_group_${id}`)
     .addClass('selected-marker')
     .hide();


### PR DESCRIPTION
The Foreman linting requires constants to be declared instead of directly assigning numbers to variables. Otherwise, it will through the 'no-magic-numbers' error.

Corresponding Foreman core PR:

theforeman/foreman#11008

Co-Authored-By: OpenAI Codex