### PR TITLE
Fixes #39540 - Host actions are disabled after bulk action

### DIFF
--- a/webpack/src/Extends/Hosts/BulkActions/BulkChangeProxyCommon/index.js
+++ b/webpack/src/Extends/Hosts/BulkActions/BulkChangeProxyCommon/index.js
@@ -15,17 +15,11 @@ import {
 } from '@patternfly/react-core';
 import { addToast } from 'foremanReact/components/ToastsList/slice';
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
-import { foremanUrl } from 'foremanReact/common/helpers';
-import { APIActions } from 'foremanReact/redux/API';
 import { STATUS } from 'foremanReact/constants';
 import {
   selectAPIStatus,
   selectAPIResponse,
 } from 'foremanReact/redux/API/APISelectors';
-import {
-  HOSTS_API_PATH,
-  API_REQUEST_KEY,
-} from 'foremanReact/routes/Hosts/constants';
 import {
   fetchSmartProxies,
   SMART_PROXY_KEY,
@@ -47,6 +41,7 @@ const BulkChangeProxyCommon = ({
   allHostsMessage,
   someHostsMessage,
   isCAProxy,
+  onSuccess: onSuccessCallback,
 }) => {
   const dispatch = useDispatch();
   const [smartProxyId, setSmartProxyId] = useState('');
@@ -112,13 +107,11 @@ const BulkChangeProxyCommon = ({
         message: response.data.message,
       })
     );
-    dispatch(
-      APIActions.get({
-        key: API_REQUEST_KEY,
-        url: foremanUrl(HOSTS_API_PATH),
-      })
-    );
-    handleModalClose();
+    try {
+      if (onSuccessCallback) onSuccessCallback();
+    } finally {
+      handleModalClose();
+    }
   };
 
   const handleConfirm = () => {
@@ -242,11 +235,13 @@ BulkChangeProxyCommon.propTypes = {
   allHostsMessage: PropTypes.string.isRequired,
   someHostsMessage: PropTypes.string.isRequired,
   isCAProxy: PropTypes.bool.isRequired,
+  onSuccess: PropTypes.func,
 };
 
 BulkChangeProxyCommon.defaultProps = {
   isOpen: false,
   closeModal: () => {},
+  onSuccess: undefined,
 };
 
 export default BulkChangeProxyCommon;

--- a/webpack/src/Extends/Hosts/BulkActions/BulkChangeProxyCommon/index.js
+++ b/webpack/src/Extends/Hosts/BulkActions/BulkChangeProxyCommon/index.js
@@ -77,6 +77,7 @@ const BulkChangeProxyCommon = ({
 
   const toggle = toggleRef => (
     <MenuToggle
+      ouiaId="bulk-change-proxy-common-select-toggle"
       ref={toggleRef}
       onClick={onToggleClick}
       isExpanded={smartProxySelectOpen}

--- a/webpack/src/Extends/Hosts/BulkActions/BulkChangePuppetCAProxy/__tests__/index.test.js
+++ b/webpack/src/Extends/Hosts/BulkActions/BulkChangePuppetCAProxy/__tests__/index.test.js
@@ -18,11 +18,13 @@ jest.mock('../../BulkChangeProxyCommon', () => ({
 
 describe('BulkChangePuppetCAProxyScene', () => {
   const fetchBulkParams = jest.fn();
+  const refreshTableData = jest.fn();
   const contextValue = {
     selectAllHostsMode: false,
     selectedCount: 2,
     selectedResults: [1, 2],
     fetchBulkParams,
+    refreshTableData,
   };
 
   beforeEach(() => {
@@ -51,6 +53,7 @@ describe('BulkChangePuppetCAProxyScene', () => {
         selectAllHostsMode: false,
         isOpen: true,
         closeModal: expect.any(Function),
+        onSuccess: refreshTableData,
         selectMessage: 'Select a Puppet CA Proxy',
         handleErrorMessage: 'Failed to change Puppet CA Proxy',
         changeMessage: 'Change Puppet CA Proxy',

--- a/webpack/src/Extends/Hosts/BulkActions/BulkChangePuppetCAProxy/index.js
+++ b/webpack/src/Extends/Hosts/BulkActions/BulkChangePuppetCAProxy/index.js
@@ -11,6 +11,7 @@ const BulkChangePuppetCAProxyScene = () => {
     selectedCount,
     selectedResults,
     fetchBulkParams,
+    refreshTableData,
   } = useContext(ForemanActionsBarContext);
   const { isOpen, close: closeModal } = useBulkModalOpen(
     'bulk-change-puppet-ca-proxy'
@@ -24,6 +25,7 @@ const BulkChangePuppetCAProxyScene = () => {
       selectAllHostsMode={selectAllHostsMode}
       isOpen={isOpen}
       closeModal={closeModal}
+      onSuccess={refreshTableData}
       selectMessage={__('Select a Puppet CA Proxy')}
       handleErrorMessage={__('Failed to change Puppet CA Proxy')}
       changeMessage={__('Change Puppet CA Proxy')}

--- a/webpack/src/Extends/Hosts/BulkActions/BulkChangePuppetProxy/__tests__/index.test.js
+++ b/webpack/src/Extends/Hosts/BulkActions/BulkChangePuppetProxy/__tests__/index.test.js
@@ -18,11 +18,13 @@ jest.mock('../../BulkChangeProxyCommon', () => ({
 
 describe('BulkChangePuppetProxyScene', () => {
   const fetchBulkParams = jest.fn();
+  const refreshTableData = jest.fn();
   const contextValue = {
     selectAllHostsMode: false,
     selectedCount: 2,
     selectedResults: [1, 2],
     fetchBulkParams,
+    refreshTableData,
   };
 
   beforeEach(() => {
@@ -51,6 +53,7 @@ describe('BulkChangePuppetProxyScene', () => {
         selectAllHostsMode: false,
         isOpen: true,
         closeModal: expect.any(Function),
+        onSuccess: refreshTableData,
         selectMessage: 'Select a Puppet Proxy',
         handleErrorMessage: 'Failed to change Puppet Proxy',
         changeMessage: 'Change Puppet Proxy',

--- a/webpack/src/Extends/Hosts/BulkActions/BulkChangePuppetProxy/index.js
+++ b/webpack/src/Extends/Hosts/BulkActions/BulkChangePuppetProxy/index.js
@@ -11,6 +11,7 @@ const BulkChangePuppetProxyScene = () => {
     selectedCount,
     selectedResults,
     fetchBulkParams,
+    refreshTableData,
   } = useContext(ForemanActionsBarContext);
   const { isOpen, close: closeModal } = useBulkModalOpen(
     'bulk-change-puppet-proxy'
@@ -24,6 +25,7 @@ const BulkChangePuppetProxyScene = () => {
       selectAllHostsMode={selectAllHostsMode}
       isOpen={isOpen}
       closeModal={closeModal}
+      onSuccess={refreshTableData}
       selectMessage={__('Select a Puppet Proxy')}
       handleErrorMessage={__('Failed to change Puppet Proxy')}
       changeMessage={__('Change Puppet Proxy')}

--- a/webpack/src/Extends/Hosts/BulkActions/BulkRemoveProxyCommon/index.js
+++ b/webpack/src/Extends/Hosts/BulkActions/BulkRemoveProxyCommon/index.js
@@ -5,12 +5,6 @@ import { useDispatch } from 'react-redux';
 import { Modal, Button, TextContent, Text } from '@patternfly/react-core';
 import { addToast } from 'foremanReact/components/ToastsList/slice';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { foremanUrl } from 'foremanReact/common/helpers';
-import { APIActions } from 'foremanReact/redux/API';
-import {
-  HOSTS_API_PATH,
-  API_REQUEST_KEY,
-} from 'foremanReact/routes/Hosts/constants';
 
 import {
   BULK_REMOVE_PUPPET_PROXY_KEY,
@@ -30,6 +24,7 @@ const BulkRemoveProxyCommon = ({
   removeMessage,
   allHostsMessage,
   someHostsMessage,
+  onSuccess: onSuccessCallback,
 }) => {
   const actionKey = isCAProxy
     ? BULK_REMOVE_PUPPET_CA_PROXY_KEY
@@ -57,13 +52,11 @@ const BulkRemoveProxyCommon = ({
         message: response.data.message,
       })
     );
-    dispatch(
-      APIActions.get({
-        key: API_REQUEST_KEY,
-        url: foremanUrl(HOSTS_API_PATH),
-      })
-    );
-    handleModalClose();
+    try {
+      if (onSuccessCallback) onSuccessCallback();
+    } finally {
+      handleModalClose();
+    }
   };
 
   const handleConfirm = () => {
@@ -153,12 +146,14 @@ BulkRemoveProxyCommon.propTypes = {
   removeMessage: PropTypes.string,
   allHostsMessage: PropTypes.string.isRequired,
   someHostsMessage: PropTypes.string.isRequired,
+  onSuccess: PropTypes.func,
 };
 
 BulkRemoveProxyCommon.defaultProps = {
   isOpen: false,
   closeModal: () => {},
   removeMessage: 'Remove Puppet (CA) Proxy',
+  onSuccess: undefined,
 };
 
 export default BulkRemoveProxyCommon;

--- a/webpack/src/Extends/Hosts/BulkActions/BulkRemovePuppetCAProxy/__tests__/index.test.js
+++ b/webpack/src/Extends/Hosts/BulkActions/BulkRemovePuppetCAProxy/__tests__/index.test.js
@@ -18,11 +18,13 @@ jest.mock('../../BulkRemoveProxyCommon', () => ({
 
 describe('BulkRemovePuppetCAProxyScene', () => {
   const fetchBulkParams = jest.fn();
+  const refreshTableData = jest.fn();
   const contextValue = {
     selectAllHostsMode: false,
     selectedCount: 2,
     selectedResults: [1, 2],
     fetchBulkParams,
+    refreshTableData,
   };
 
   beforeEach(() => {
@@ -51,6 +53,7 @@ describe('BulkRemovePuppetCAProxyScene', () => {
         fetchBulkParams,
         isOpen: true,
         closeModal: expect.any(Function),
+        onSuccess: refreshTableData,
         handleErrorMessage: 'Failed to remove Puppet CA Proxy',
         allHostsMessage:
           'Removing the Puppet CA proxy will affect {boldCount} selected hosts. Warning: If a Puppet Proxy is still set, the Puppet CA Proxy will fall back to that value after removal!',

--- a/webpack/src/Extends/Hosts/BulkActions/BulkRemovePuppetCAProxy/index.js
+++ b/webpack/src/Extends/Hosts/BulkActions/BulkRemovePuppetCAProxy/index.js
@@ -10,6 +10,7 @@ const BulkRemovePuppetCAProxyScene = () => {
     selectedCount,
     selectedResults,
     fetchBulkParams,
+    refreshTableData,
   } = useContext(ForemanActionsBarContext);
   const { isOpen, close: closeModal } = useBulkModalOpen(
     'bulk-remove-puppet-ca-proxy'
@@ -24,6 +25,7 @@ const BulkRemovePuppetCAProxyScene = () => {
       fetchBulkParams={fetchBulkParams}
       isOpen={isOpen}
       closeModal={closeModal}
+      onSuccess={refreshTableData}
       handleErrorMessage={__('Failed to remove Puppet CA Proxy')}
       allHostsMessage={__(
         'Removing the Puppet CA proxy will affect {boldCount} selected hosts. Warning: If a Puppet Proxy is still set, the Puppet CA Proxy will fall back to that value after removal!'

--- a/webpack/src/Extends/Hosts/BulkActions/BulkRemovePuppetProxy/__tests__/index.test.js
+++ b/webpack/src/Extends/Hosts/BulkActions/BulkRemovePuppetProxy/__tests__/index.test.js
@@ -18,11 +18,13 @@ jest.mock('../../BulkRemoveProxyCommon', () => ({
 
 describe('BulkRemovePuppetProxyScene', () => {
   const fetchBulkParams = jest.fn();
+  const refreshTableData = jest.fn();
   const contextValue = {
     selectAllHostsMode: false,
     selectedCount: 2,
     selectedResults: [1, 2],
     fetchBulkParams,
+    refreshTableData,
   };
 
   beforeEach(() => {
@@ -51,6 +53,7 @@ describe('BulkRemovePuppetProxyScene', () => {
         fetchBulkParams,
         isOpen: true,
         closeModal: expect.any(Function),
+        onSuccess: refreshTableData,
         handleErrorMessage: 'Failed to remove Puppet Proxy',
         removeMessage: 'Remove Puppet Proxy',
       })

--- a/webpack/src/Extends/Hosts/BulkActions/BulkRemovePuppetProxy/index.js
+++ b/webpack/src/Extends/Hosts/BulkActions/BulkRemovePuppetProxy/index.js
@@ -10,6 +10,7 @@ const BulkRemovePuppetProxyScene = () => {
     selectedCount,
     selectedResults,
     fetchBulkParams,
+    refreshTableData,
   } = useContext(ForemanActionsBarContext);
   const { isOpen, close: closeModal } = useBulkModalOpen(
     'bulk-remove-puppet-proxy'
@@ -24,6 +25,7 @@ const BulkRemovePuppetProxyScene = () => {
       fetchBulkParams={fetchBulkParams}
       isOpen={isOpen}
       closeModal={closeModal}
+      onSuccess={refreshTableData}
       handleErrorMessage={__('Failed to remove Puppet Proxy')}
       allHostsMessage={__(
         'Removing the Puppet proxy will affect {boldCount} selected hosts.'


### PR DESCRIPTION
depends on https://github.com/theforeman/foreman/pull/11110
to test: 
user has permissions to edit hosts
go to new host index
click on host kebab - edit is enabled
run X action
edit is still enabled. 

Disclaimer: I only tested this on foreman core - change location bulk action. since all code looks the same I assume it will still work, but testing is encouraged. 
