### PR TITLE
Fixes #39620 - Fix Puppet search autocomplete

### DIFF
--- a/app/models/concerns/foreman_puppet/extensions/host.rb
+++ b/app/models/concerns/foreman_puppet/extensions/host.rb
@@ -13,9 +13,9 @@ module ForemanPuppet
         include_in_clone puppet: %i[config_groups host_config_groups host_classes]
 
         scoped_search relation: :environment, on: :name, complete_value: true, rename: :environment
-        scoped_search relation: :puppetclasses, on: :name, complete_value: true, rename: :puppetclass, only_explicit: true, operators: ['= ', '~ '],
+        scoped_search relation: :search_puppetclasses, on: :name, complete_value: true, rename: :puppetclass, only_explicit: true, operators: ['= ', '~ '],
           ext_method: :search_by_puppetclass
-        scoped_search relation: :config_groups, on: :name, complete_value: true, rename: :config_group, only_explicit: true, operators: ['= ', '~ '],
+        scoped_search relation: :search_config_groups, on: :name, complete_value: true, rename: :config_group, only_explicit: true, operators: ['= ', '~ '],
           ext_method: :search_by_config_group
       end
 

--- a/app/models/concerns/foreman_puppet/extensions/host_common.rb
+++ b/app/models/concerns/foreman_puppet/extensions/host_common.rb
@@ -3,6 +3,41 @@ module ForemanPuppet
     module HostCommon
       extend ActiveSupport::Concern
 
+      ASSIGNMENT_RELATIONS = %i[search_puppetclasses search_config_groups].freeze
+
+      included do
+        singleton_class.prepend CompletionMethods
+
+        has_many :search_puppetclasses, through: :puppet, source: :puppetclasses, class_name: '::ForemanPuppet::Puppetclass'
+        has_many :search_config_groups, through: :puppet, source: :config_groups, class_name: '::ForemanPuppet::ConfigGroup'
+      end
+
+      module CompletionMethods
+        def complete_for(query, options = {})
+          return super if query.nil?
+
+          completer = AssignmentCompleter.new(scoped_search_definition, query, options)
+          return super unless completer.assignment_field?
+
+          completer.build_autocomplete_options
+        end
+      end
+
+      class AssignmentCompleter < ScopedSearch::AutoCompleteBuilder
+        def assignment_field?
+          return false unless complete_options(last_node).include?(:value)
+
+          token = last_token_is(COMPARISON_OPERATORS) ? tokens[-2] : tokens[-3]
+          ASSIGNMENT_RELATIONS.include?(definition.field_by_name(token)&.relation)
+        end
+
+        def completer_scope(field)
+          return super unless ASSIGNMENT_RELATIONS.include?(field.relation)
+
+          field.klass.completer_scope(@options).reorder(Arel.sql(field.quoted_field))
+        end
+      end
+
       def all_puppetclasses(env = environment)
         return ForemanPuppet::Puppetclass.none unless puppet
         puppet.all_puppetclasses(env)

--- a/app/models/concerns/foreman_puppet/extensions/hostgroup.rb
+++ b/app/models/concerns/foreman_puppet/extensions/hostgroup.rb
@@ -16,13 +16,13 @@ module ForemanPuppet
 
         # will need through relation to work properly
         scoped_search relation: :environment, on: :name, complete_value: true, rename: :environment, only_explicit: true
-        scoped_search relation: :puppetclasses, on: :name,
+        scoped_search relation: :search_puppetclasses, on: :name,
           complete_value: true,
           rename: :puppetclass,
           only_explicit: true,
           operators: ['= ', '~ '],
           ext_method: :search_by_puppetclass
-        scoped_search relation: :config_groups, on: :name,
+        scoped_search relation: :search_config_groups, on: :name,
           complete_value: true,
           rename: :config_group,
           only_explicit: true,
@@ -45,9 +45,16 @@ module ForemanPuppet
         def search_by_puppetclass(_key, operator, value)
           conditions = sanitize_sql_for_conditions(["puppetclasses.name #{operator} ?", value_to_sql(operator, value)])
           hostgroup_ids = ::Hostgroup.joins(puppet: :puppetclasses).where(conditions).map(&:subtree_ids)
+          config_group_ids = ForemanPuppet::ConfigGroup.joins(:puppetclasses).where(conditions).pluck(:id)
+          if config_group_ids.any?
+            hostgroup_cg_ids = ForemanPuppet::HostgroupPuppetFacet.joins(:host_config_groups)
+                                                                  .where(host_config_groups: { config_group_id: config_group_ids })
+                                                                  .pluck(:hostgroup_id)
+            hostgroup_ids += ::Hostgroup.where(id: hostgroup_cg_ids).map(&:subtree_ids)
+          end
 
           conds = []
-          conds << "hostgroups.id IN (#{hostgroup_ids.join(',')})" if hostgroup_ids.present?
+          conds << "hostgroups.id IN (#{hostgroup_ids.uniq.join(',')})" if hostgroup_ids.present?
 
           { conditions: conds.join(' OR ').presence || 'hostgroups.id < 0' }
         end

--- a/app/models/foreman_puppet/config_group.rb
+++ b/app/models/foreman_puppet/config_group.rb
@@ -16,6 +16,8 @@ module ForemanPuppet
 
     validates :name, presence: true, uniqueness: true
 
+    scope :assigned_to_hosts, -> { where(id: ForemanPuppet::HostConfigGroup.select(:config_group_id)) }
+
     scoped_search on: :name, complete_value: true
     scoped_search relation: :puppetclasses, on: :name, complete_value: true, rename: :puppetclass, only_explicit: true, operators: ['= ', '~ ']
 
@@ -40,6 +42,10 @@ module ForemanPuppet
 
     def hostgroups_count
       ::Hostgroup.authorized.search_for(%(config_group="#{name}")).size
+    end
+
+    def self.completer_scope(options)
+      super.merge(assigned_to_hosts)
     end
   end
 end

--- a/app/models/foreman_puppet/puppetclass.rb
+++ b/app/models/foreman_puppet/puppetclass.rb
@@ -41,6 +41,16 @@ module ForemanPuppet
 
     default_scope -> { order(:name) }
 
+    scope :assigned_to_hosts, lambda {
+      direct = ForemanPuppet::HostClass.select(:puppetclass_id)
+      via_hostgroup = ForemanPuppet::HostgroupClass.select(:puppetclass_id)
+      via_config_group = ForemanPuppet::ConfigGroupClass
+                         .where(config_group_id: ForemanPuppet::HostConfigGroup.select(:config_group_id))
+                         .select(:puppetclass_id)
+
+      where(id: direct).or(where(id: via_hostgroup)).or(where(id: via_config_group))
+    }
+
     scoped_search on: :name, complete_value: true
     scoped_search relation: :environments, on: :name, complete_value: true, rename: 'environment'
     scoped_search relation: :organizations, on: :name, complete_value: true, rename: 'organization', only_explicit: true
@@ -141,6 +151,10 @@ module ForemanPuppet
 
       puppet_classes = (direct + indirect).uniq
       { conditions: "puppetclasses.id IN(#{puppet_classes.join(',')})" }
+    end
+
+    def self.completer_scope(options)
+      super.merge(assigned_to_hosts)
     end
   end
 end

--- a/test/models/foreman_puppet/host_test.rb
+++ b/test/models/foreman_puppet/host_test.rb
@@ -117,6 +117,72 @@ module ForemanPuppet
       end
     end
 
+    describe '#complete_for' do
+      let(:host) { FactoryBot.create(:host, :with_puppet_enc, :with_puppetclass) }
+
+      test 'can complete Puppet class values' do
+        puppetclass = host.puppet.puppetclasses.first
+        completions = ::Host::Managed.complete_for("puppetclass = #{puppetclass.name}")
+
+        assert_includes completions, %(puppetclass =  "#{puppetclass.name}")
+      end
+
+      test 'can complete config group values' do
+        config_group = FactoryBot.create(:config_group)
+        host.puppet.config_groups << config_group
+        completions = ::Host::Managed.complete_for("config_group = #{config_group.name}")
+
+        assert_includes completions, %(config_group =  "#{config_group.name}")
+      end
+
+      test 'can complete Puppet class values inherited from a hostgroup' do
+        hostgroup = FactoryBot.create(:hostgroup, :with_puppet_enc, :with_puppetclass)
+        FactoryBot.create(:host, hostgroup: hostgroup)
+        puppetclass = hostgroup.puppet.puppetclasses.first
+        completions = ::Host::Managed.complete_for("puppetclass = #{puppetclass.name}")
+
+        assert_includes completions, %(puppetclass =  "#{puppetclass.name}")
+      end
+
+      test 'can complete Puppet class values assigned through a config group' do
+        config_group = FactoryBot.create(:config_group, :with_puppetclass)
+        host.puppet.config_groups << config_group
+        puppetclass = config_group.puppetclasses.first
+        completions = ::Host::Managed.complete_for("puppetclass = #{puppetclass.name}")
+
+        assert_includes completions, %(puppetclass =  "#{puppetclass.name}")
+      end
+
+      test 'can complete config group values inherited from a hostgroup' do
+        hostgroup = FactoryBot.create(:hostgroup, :with_puppet_enc, :with_config_group)
+        FactoryBot.create(:host, hostgroup: hostgroup)
+        config_group = hostgroup.puppet.config_groups.first
+        completions = ::Host::Managed.complete_for("config_group = #{config_group.name}")
+
+        assert_includes completions, %(config_group =  "#{config_group.name}")
+      end
+
+      test 'does not complete unassigned Puppet class values' do
+        puppetclass = FactoryBot.create(:puppetclass)
+        completions = ::Host::Managed.complete_for("puppetclass = #{puppetclass.name}")
+
+        assert_not_includes completions, %(puppetclass =  "#{puppetclass.name}")
+      end
+
+      test 'does not complete unassigned config group values' do
+        config_group = FactoryBot.create(:config_group)
+        completions = ::Host::Managed.complete_for("config_group = #{config_group.name}")
+
+        assert_not_includes completions, %(config_group =  "#{config_group.name}")
+      end
+
+      test 'preserves core host value completions' do
+        completions = as_admin { ::Host::Managed.complete_for('user.login =') }
+
+        assert_includes completions, 'user.login = current_user'
+      end
+    end
+
     describe '#info puppet bits' do
       test 'ENC YAML omits environment if no puppet facet' do
         host = FactoryBot.build_stubbed(:host)

--- a/test/models/foreman_puppet/hostgroup_test.rb
+++ b/test/models/foreman_puppet/hostgroup_test.rb
@@ -22,5 +22,37 @@ module ForemanPuppet
       assert_includes hostgroup.puppet.puppetclasses, puppet_class
       assert_includes hostgroup.puppetclasses, puppet_class
     end
+
+    test 'can complete Puppet class values' do
+      puppetclass = FactoryBot.create(:puppetclass)
+      hostgroup.puppet.puppetclasses << puppetclass
+      completions = ::Hostgroup.complete_for("puppetclass = #{puppetclass.name}")
+
+      assert_includes completions, %(puppetclass =  "#{puppetclass.name}")
+    end
+
+    test 'can complete config group values' do
+      config_group = hostgroup.puppet.config_groups.first
+      completions = ::Hostgroup.complete_for("config_group = #{config_group.name}")
+
+      assert_includes completions, %(config_group =  "#{config_group.name}")
+    end
+
+    test 'can complete Puppet class values inherited from a parent hostgroup' do
+      parent = FactoryBot.create(:hostgroup, :with_puppet_enc, :with_puppetclass)
+      FactoryBot.create(:hostgroup, parent: parent)
+      puppetclass = parent.puppet.puppetclasses.first
+      completions = ::Hostgroup.complete_for("puppetclass = #{puppetclass.name}")
+
+      assert_includes completions, %(puppetclass =  "#{puppetclass.name}")
+    end
+
+    test 'searches Puppet class values assigned through a config group' do
+      config_group = hostgroup.puppet.config_groups.first
+      puppetclass = FactoryBot.create(:puppetclass)
+      config_group.puppetclasses << puppetclass
+
+      assert_includes ::Hostgroup.search_for("puppetclass = #{puppetclass.name}"), hostgroup
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes [#39620](https://projects.theforeman.org/issues/39620) and addresses [GitHub issue #365](https://github.com/theforeman/foreman_puppet/issues/365).

Autocomplete for `puppetclass` and `config_group` raised an exception because their scoped-search definitions referenced regular Ruby helper methods rather than Active Record associations. Scoped-search requires an association reflection to determine the related model when completing values.

Add dedicated through associations for scoped-search metadata and named scopes that select Puppet classes and config groups assigned directly, through host groups, or through config groups. A scoped-search autocomplete builder uses these scopes for the two Puppet fields while leaving all other Foreman completions unchanged. Host group Puppet class search now also includes classes assigned through config groups.

The existing `puppetclasses` helper remains unchanged, including its behavior of building a missing Puppet facet when classes are assigned.

## Testing

- Ruby syntax and whitespace checks pass for all changed files
- Regression tests cover direct, inherited host group, and config group completion paths
- Regression tests exclude unassigned values and preserve Foreman core value completion
- Host group search coverage includes Puppet classes assigned through config groups

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the issue was investigated and the changes, tests, and PR wording were prepared with the assistance of Codex 5.6 Sol High. The resulting changes were reviewed before submitting. The commit also includes an `Assisted-By` trailer.
