### PR TITLE
Fixes #39683 - Scope host group Puppet class completion

### DIFF
--- a/app/models/concerns/foreman_puppet/extensions/host_common.rb
+++ b/app/models/concerns/foreman_puppet/extensions/host_common.rb
@@ -34,7 +34,8 @@ module ForemanPuppet
         def completer_scope(field)
           return super unless ASSIGNMENT_RELATIONS.include?(field.relation)
 
-          field.klass.completer_scope(@options).reorder(Arel.sql(field.quoted_field))
+          options = @options.merge(autocomplete_resource: definition.klass)
+          field.klass.completer_scope(options).reorder(Arel.sql(field.quoted_field))
         end
       end
 

--- a/app/models/foreman_puppet/puppetclass.rb
+++ b/app/models/foreman_puppet/puppetclass.rb
@@ -51,6 +51,24 @@ module ForemanPuppet
       where(id: direct).or(where(id: via_hostgroup)).or(where(id: via_config_group))
     }
 
+    scope :assigned_to_hostgroups, lambda {
+      hostgroup_facets = ForemanPuppet::HostgroupPuppetFacet
+                         .where(hostgroup_id: ::Hostgroup.unscoped.with_taxonomy_scope.reorder(nil).select(:id))
+                         .select(:id)
+      direct = ForemanPuppet::HostgroupClass
+               .where(hostgroup_puppet_facet_id: hostgroup_facets)
+               .select(:puppetclass_id)
+      config_groups = ForemanPuppet::HostConfigGroup
+                      .where(
+                        host_type: ForemanPuppet::HostgroupPuppetFacet.polymorphic_name,
+                        host_id: hostgroup_facets
+                      )
+                      .select(:config_group_id)
+      via_config_group = ForemanPuppet::ConfigGroupClass.where(config_group_id: config_groups).select(:puppetclass_id)
+
+      where(id: direct).or(where(id: via_config_group))
+    }
+
     scoped_search on: :name, complete_value: true
     scoped_search relation: :environments, on: :name, complete_value: true, rename: 'environment'
     scoped_search relation: :organizations, on: :name, complete_value: true, rename: 'organization', only_explicit: true
@@ -154,7 +172,8 @@ module ForemanPuppet
     end
 
     def self.completer_scope(options)
-      super.merge(assigned_to_hosts)
+      assignment_scope = options[:autocomplete_resource] == ::Hostgroup ? assigned_to_hostgroups : assigned_to_hosts
+      super.merge(assignment_scope)
     end
   end
 end

--- a/test/models/foreman_puppet/hostgroup_test.rb
+++ b/test/models/foreman_puppet/hostgroup_test.rb
@@ -47,6 +47,23 @@ module ForemanPuppet
       assert_includes completions, %(puppetclass =  "#{puppetclass.name}")
     end
 
+    test 'can complete Puppet class values assigned through a config group' do
+      config_group = hostgroup.puppet.config_groups.first
+      puppetclass = FactoryBot.create(:puppetclass)
+      config_group.puppetclasses << puppetclass
+      completions = ::Hostgroup.complete_for("puppetclass = #{puppetclass.name}")
+
+      assert_includes completions, %(puppetclass =  "#{puppetclass.name}")
+    end
+
+    test 'does not complete Puppet class values assigned only to hosts' do
+      host = FactoryBot.create(:host, :with_puppet_enc, :with_puppetclass)
+      puppetclass = host.puppet.puppetclasses.first
+      completions = ::Hostgroup.complete_for("puppetclass = #{puppetclass.name}")
+
+      assert_not_includes completions, %(puppetclass =  "#{puppetclass.name}")
+    end
+
     test 'searches Puppet class values assigned through a config group' do
       config_group = hostgroup.puppet.config_groups.first
       puppetclass = FactoryBot.create(:puppetclass)


### PR DESCRIPTION
## Summary

Fixes [#39683](https://projects.theforeman.org/issues/39683) as a follow-up to [foreman_puppet #450](https://github.com/theforeman/foreman_puppet/pull/450).

Host group Puppet class completion reused the host assignment scope, so it suggested classes assigned only to hosts. Pass the resource being completed to the Puppet class completer and use a dedicated host group assignment scope restricted to host groups visible in the current organization and location. Direct and inherited host group assignments and classes provided through config groups remain available.

## Testing

- Ruby syntax checks pass for all changed files
- `git diff --check` passes
- Regression coverage includes classes assigned through host group config groups and excludes classes assigned only to hosts
- Full Rails tests are left to CI

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the issue was investigated and the changes, tests, and PR wording were prepared with the assistance of Codex 5.6 Sol High. The resulting changes were reviewed before submitting. The commit also includes an `Assisted-By` trailer.
